### PR TITLE
Add logic to force the min date return

### DIFF
--- a/FSCalendar/FSCalendarExtensions.m
+++ b/FSCalendar/FSCalendarExtensions.m
@@ -190,7 +190,7 @@
     NSDate *lastDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
     lastDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:lastDayOfWeek options:0];
     components.day = NSIntegerMax;
-    if (firstDayOfWeek < week) {
+    if (lastDayOfWeek < week) {
         return week;
     } else { 
         return lastDayOfWeek;
@@ -207,7 +207,7 @@
     NSDateComponents *components = [self components:NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour fromDate:middleDayOfWeek];
     middleDayOfWeek = [self dateFromComponents:components];
     componentsToSubtract.day = NSIntegerMax;
-    if (firstDayOfWeek < week) {
+    if (middleDayOfWeek < week) {
         return week;
     } else { 
         return middleDayOfWeek;

--- a/FSCalendar/FSCalendarExtensions.m
+++ b/FSCalendar/FSCalendarExtensions.m
@@ -173,7 +173,11 @@
     NSDate *firstDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
     firstDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:firstDayOfWeek options:0];
     components.day = NSIntegerMax;
-    return firstDayOfWeek;
+    if (firstDayOfWeek < week) {
+        return week;
+    } else { 
+        return firstDayOfWeek;
+    }
 }
 
 - (nullable NSDate *)fs_lastDayOfWeek:(NSDate *)week
@@ -186,7 +190,11 @@
     NSDate *lastDayOfWeek = [self dateByAddingComponents:components toDate:week options:0];
     lastDayOfWeek = [self dateBySettingHour:0 minute:0 second:0 ofDate:lastDayOfWeek options:0];
     components.day = NSIntegerMax;
-    return lastDayOfWeek;
+    if (firstDayOfWeek < week) {
+        return week;
+    } else { 
+        return lastDayOfWeek;
+    }
 }
 
 - (nullable NSDate *)fs_middleDayOfWeek:(NSDate *)week
@@ -199,7 +207,11 @@
     NSDateComponents *components = [self components:NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour fromDate:middleDayOfWeek];
     middleDayOfWeek = [self dateFromComponents:components];
     componentsToSubtract.day = NSIntegerMax;
-    return middleDayOfWeek;
+    if (firstDayOfWeek < week) {
+        return week;
+    } else { 
+        return middleDayOfWeek;
+    }
 }
 
 - (NSInteger)fs_numberOfDaysInMonth:(NSDate *)month


### PR DESCRIPTION
Lorsque nous utilisons le voice over, il y a un crash causé par un bug dans la logique de calcul du premier jour de l'intervalle du FSCalendar. Alors, comme avec le voice over la date sélectionnée automatiquement est la date minimale de l'intervalle de la bibliothèque, mais dans ces fonctions le calcul finit par créer une date invalide 1969/12/29, causant un crash avec ce message d'erreur 'FSCalendar date out of bounds exception', reason: 'Target date 1969/12/29 beyond bounds [1970/01/01 - 2099/12/31]'.