### PR TITLE
Fix voice-over crash

### DIFF
--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -658,6 +658,10 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         }
     }
     
+    // Work-around : When voice over triggers a scroll, this current delegate is always called with a targetContentOffset of 0,0
+    // which sends the calendar to the minimum date, 1970 and causes a crash
+    if (targetOffset == 0 ) { return; }
+
     NSInteger sections = lrint(targetOffset/contentSize);
     NSDate *targetPage = nil;
     switch (_scope) {


### PR DESCRIPTION
J’ai faite quelques lecture hier à propos de l’accessibilité, c’est un monde fascinant.
Jai trouvé un work-around ce matin en troubleshoot le code de la lib qui appel notre delegate calendarCurrentPageDidChange il semblerait que le problème vienne de la méthode delegate - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset Lorsque que l’événement est lancé par un module tel que voiceover, le targetContentOffset est toujours un CGPoInt(0,0), Donc ceci selon mes observations patch le problème et explique pourquoi le calendar pick la date minimum 1970